### PR TITLE
add quoth entry to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3067,5 +3067,13 @@
         "description": "Provides a Find/Replace dialog which optionally supports regular expressions and scope (full document or text selection).",
         "author": "Martin Eder",
         "repo": "Gru80/obsidian-regex-replace"
+    },
+    {
+        "id": "quoth",
+        "name": "Quoth",
+        "description": "More flexible embedding.",
+        "author": "Eric Rykwalder",
+        "repo": "erykwalder/quoth",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/erykwalder/quoth

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
